### PR TITLE
Patch 4

### DIFF
--- a/15_bastion_services.yaml
+++ b/15_bastion_services.yaml
@@ -8,12 +8,14 @@
   vars:
     nodes: "{{ cluster['masters'] + cluster['workers']  +   cluster['bootstrap'] }}"
     number_of_nodes: "{{ nodes | length }}"
+    master_nodes: "{{ cluster['masters'] }}"
+    number_of_masters: "{{ master_nodes | length }}"
     nodes_calculated_data: []
     ip_template:
-      primary_ip: "{{  networking.internal_network[:-1] + item }}"
+      primary_ip: "{{ lb.lb_internal_network_ip | ipmath(item | int) }}"
       mac_address: "{{ nodes[ (number_of_nodes | int ) - (item | int) ].mac }}"
-      reverse_dns: "{{ ( networking.internal_network[:-1] + item ) | ipaddr('revdns')  }}"
-          
+      reverse_dns: "{{ lb.lb_internal_network_ip | ipmath(item | int) | ipaddr('revdns')  }}"
+      
   tasks:
     
     - name: Calculating number of node (Bastion)
@@ -22,7 +24,7 @@
     - name: Setting calculated data (Bastion)
       set_fact:
         nodes_calculated_data: "{{ nodes_calculated_data + [ip_template] }}"
-      with_sequence: "start=3 count={{ number_of_nodes }}"
+      with_sequence: "start=1 count={{ number_of_nodes }}"
     
     - block:
          
@@ -73,8 +75,6 @@
             src: templates/pxeboot_default.j2
             dest: /var/lib/tftpboot/pxelinux.cfg/default
     
-        
-
         - name: Configure {{ networking.public_interface_name }} to use {{ networking.internal_network_ip }} as DNS server
           command: nmcli con mod {{ networking.public_interface_name }} ipv4.dns "{{ networking.internal_network_ip }}" 
 

--- a/templates/dnsmasq.j2
+++ b/templates/dnsmasq.j2
@@ -5,7 +5,7 @@
 
 ## External dns ##
 
-server={{  networking.external_dns }}
+server={{ networking.external_dns }}
 
 ## External dns end ##
 
@@ -87,7 +87,7 @@ dhcp-host={{ node_data.mac_address }},{{  node_data.primary_ip }}
 
 ## SRV records for etcd service. Priority must be 0 and Weight must be 10 ###
 
-{% for i in range(0,3): %}
+{% for i in range(0, ( number_of_masters | int ) ) -%}
 srv-host=_etcd-server-ssl._tcp{{ cluster_domain }},etcd-{{ (i | string)+ cluster_domain }},2380,0,10
 {%endfor%}
 


### PR DESCRIPTION
Possible fix to allow a variable number of master nodes to be rendered in the SRV record creation.

Different management of IP allocation based on the first IP starting from LoadBalancer IP